### PR TITLE
make 3.0 and 4.0 consistent

### DIFF
--- a/XML-schema-definitions/3.0/fashion_rcp_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_rcp_3.0.xsd
@@ -3,7 +3,7 @@
 $Date: 2019-09-23 07:38:41 +0200 (Mon, 23 Sep 2019) $
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_rcp_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_rcp_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="http://content.cb.nl/xsd/saleskitfashion/simple_types_3.0.xsd"/>
+	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
 	<!-- 
 || Some general simple-type definitions
  -->

--- a/XML-schema-definitions/3.0/fashion_rcp_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_rcp_3.0.xsd
@@ -2,8 +2,8 @@
 <!--  $Revision: 40606 $ 
 $Date: 2019-09-23 07:38:41 +0200 (Mon, 23 Sep 2019) $
  -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_rcp_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_rcp_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_rcp_3.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_rcp_3.0.xsd" elementFormDefault="qualified">
+	<xs:include schemaLocation="simple_types_3.0.xsd"/>
 	<!-- 
 || Some general simple-type definitions
  -->

--- a/XML-schema-definitions/3.0/fashion_rcp_confirm_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_rcp_confirm_3.0.xsd
@@ -2,8 +2,8 @@
 <!--  $Revision: 24356 $
 $Date: 2017-06-29 11:22:19 +0200 (do, 29 jun 2017) $
  -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_rcp_confirm_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_rcp_confirm_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_rcp_confirm_3.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_rcp_confirm_3.0.xsd" elementFormDefault="qualified">
+	<xs:include schemaLocation="simple_types_3.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/3.0/fashion_rcp_confirm_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_rcp_confirm_3.0.xsd
@@ -3,7 +3,7 @@
 $Date: 2017-06-29 11:22:19 +0200 (do, 29 jun 2017) $
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_rcp_confirm_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_rcp_confirm_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="http://content.cb.nl/xsd/saleskitfashion/simple_types_3.0.xsd"/>
+	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/3.0/fashion_rcp_impres_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_rcp_impres_3.0.xsd
@@ -3,7 +3,7 @@
 $Date: 2017-06-29 11:22:19 +0200 (do, 29 jun 2017) $
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_rcp_impres_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_rcp_impres_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="http://content.cb.nl/xsd/saleskitfashion/simple_types_3.0.xsd"/>
+	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/3.0/fashion_rcp_impres_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_rcp_impres_3.0.xsd
@@ -2,8 +2,8 @@
 <!--  $Revision: 24356 $
 $Date: 2017-06-29 11:22:19 +0200 (do, 29 jun 2017) $
  -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_rcp_impres_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_rcp_impres_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_rcp_impres_3.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_rcp_impres_3.0.xsd" elementFormDefault="qualified">
+	<xs:include schemaLocation="simple_types_3.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/3.0/fashion_shp_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_shp_3.0.xsd
@@ -2,8 +2,8 @@
 <!--  $Revision: 48470 $
 $Date: 2021-04-16 14:52:40 +0200 (Fri, 16 Apr 2021) $
  -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_shp_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_shp_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_shp_3.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_shp_3.0.xsd" elementFormDefault="qualified">
+	<xs:include schemaLocation="simple_types_3.0.xsd"/>
 	<!-- 
 || Some general simple-type definitions
  -->

--- a/XML-schema-definitions/3.0/fashion_shp_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_shp_3.0.xsd
@@ -3,7 +3,7 @@
 $Date: 2021-04-16 14:52:40 +0200 (Fri, 16 Apr 2021) $
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_shp_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_shp_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="http://content.cb.nl/xsd/saleskitfashion/simple_types_3.0.xsd"/>
+	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
 	<!-- 
 || Some general simple-type definitions
  -->

--- a/XML-schema-definitions/3.0/fashion_shp_confirm_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_shp_confirm_3.0.xsd
@@ -3,8 +3,8 @@
 <!--  $Revision: 24356 $
 $Date: 2017-06-29 11:22:19 +0200 (do, 29 jun 2017) $
  -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_shp_confirm_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_shp_confirm_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_shp_confirm_3.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_shp_confirm_3.0.xsd" elementFormDefault="qualified">
+	<xs:include schemaLocation="simple_types_3.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/3.0/fashion_shp_confirm_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_shp_confirm_3.0.xsd
@@ -4,7 +4,7 @@
 $Date: 2017-06-29 11:22:19 +0200 (do, 29 jun 2017) $
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_shp_confirm_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_shp_confirm_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="http://content.cb.nl/xsd/saleskitfashion/simple_types_3.0.xsd"/>
+	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/3.0/fashion_shp_impres_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_shp_impres_3.0.xsd
@@ -4,7 +4,7 @@
 $Date: 2017-06-29 11:22:19 +0200 (do, 29 jun 2017) $
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_shp_impres_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_shp_impres_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="http://content.cb.nl/xsd/saleskitfashion/simple_types_3.0.xsd"/>
+	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/3.0/fashion_shp_impres_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_shp_impres_3.0.xsd
@@ -3,8 +3,8 @@
 <!--  $Revision: 24356 $
 $Date: 2017-06-29 11:22:19 +0200 (do, 29 jun 2017) $
  -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_shp_impres_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_shp_impres_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_shp_impres_3.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_shp_impres_3.0.xsd" elementFormDefault="qualified">
+	<xs:include schemaLocation="simple_types_3.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/3.0/fashion_sku_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_sku_3.0.xsd
@@ -3,7 +3,7 @@
 $Date: 2018-03-05 16:10:22 +0100 (ma, 05 mrt 2018) $
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_sku_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_sku_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="http://content.cb.nl/xsd/saleskitfashion/simple_types_3.0.xsd"/>
+	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/3.0/fashion_sku_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_sku_3.0.xsd
@@ -2,8 +2,8 @@
 <!--  $Revision: 29583 $
 $Date: 2018-03-05 16:10:22 +0100 (ma, 05 mrt 2018) $
  -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_sku_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_sku_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_sku_3.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_sku_3.0.xsd" elementFormDefault="qualified">
+	<xs:include schemaLocation="simple_types_3.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/3.0/fashion_sku_impres_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_sku_impres_3.0.xsd
@@ -3,7 +3,7 @@
 $Date: 2017-06-29 11:22:19 +0200 (do, 29 jun 2017) $
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_sku_impres_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_sku_impres_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="http://content.cb.nl/xsd/saleskitfashion/simple_types_3.0.xsd"/>
+	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/3.0/fashion_sku_impres_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_sku_impres_3.0.xsd
@@ -2,8 +2,8 @@
 <!--  $Revision: 24356 $
 $Date: 2017-06-29 11:22:19 +0200 (do, 29 jun 2017) $
  -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_sku_impres_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_sku_impres_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_sku_impres_3.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_sku_impres_3.0.xsd" elementFormDefault="qualified">
+	<xs:include schemaLocation="simple_types_3.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/3.0/fashion_stock_level_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_stock_level_3.0.xsd
@@ -3,7 +3,7 @@
 $Date: 2017-06-29 11:22:19 +0200 (do, 29 jun 2017) $
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_stock_level_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_stock_level_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="http://content.cb.nl/xsd/saleskitfashion/simple_types_3.0.xsd"/>
+	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/3.0/fashion_stock_level_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_stock_level_3.0.xsd
@@ -2,8 +2,8 @@
 <!--  $Revision: 24356 $
 $Date: 2017-06-29 11:22:19 +0200 (do, 29 jun 2017) $
  -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_stock_level_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_stock_level_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_stock_level_3.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_stock_level_3.0.xsd" elementFormDefault="qualified">
+	<xs:include schemaLocation="simple_types_3.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/3.0/fashion_stock_mutation_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_stock_mutation_3.0.xsd
@@ -3,7 +3,7 @@
 $Date: 2017-06-29 11:22:19 +0200 (do, 29 jun 2017) $
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_stock_mutation_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_stock_mutation_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="http://content.cb.nl/xsd/saleskitfashion/simple_types_3.0.xsd"/>
+	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/3.0/fashion_stock_mutation_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_stock_mutation_3.0.xsd
@@ -2,8 +2,8 @@
 <!--  $Revision: 24356 $
 $Date: 2017-06-29 11:22:19 +0200 (do, 29 jun 2017) $
  -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://content.cb.nl/xsd/saleskitfashion/fashion_stock_mutation_3.0.xsd" targetNamespace="http://content.cb.nl/xsd/saleskitfashion/fashion_stock_mutation_3.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/simple_types_3.0.xsd"/>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_stock_mutation_3.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_stock_mutation_3.0.xsd" elementFormDefault="qualified">
+	<xs:include schemaLocation="simple_types_3.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/4.0/fashion_rcp_4.0.xsd
+++ b/XML-schema-definitions/4.0/fashion_rcp_4.0.xsd
@@ -3,7 +3,7 @@
 $Date: 2022-04-22 11:00:00 +0200 (Tue, 12 Apr 2022) $
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_rcp_4.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_rcp_4.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/simple_types_4.0.xsd"/>
+	<xs:include schemaLocation="simple_types_4.0.xsd"/>
 	<!-- 
 || Some general simple-type definitions
  -->

--- a/XML-schema-definitions/4.0/fashion_rcp_confirm_4.0.xsd
+++ b/XML-schema-definitions/4.0/fashion_rcp_confirm_4.0.xsd
@@ -3,7 +3,7 @@
 $Date: 2022-04-22 16:30:00 +0200 (Tue, 12 Apr 2022) $
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_rcp_confirm_4.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_rcp_confirm_4.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/simple_types_4.0.xsd"/>
+	<xs:include schemaLocation="simple_types_4.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/4.0/fashion_rcp_impres_4.0.xsd
+++ b/XML-schema-definitions/4.0/fashion_rcp_impres_4.0.xsd
@@ -3,7 +3,7 @@
 $Date: 2022-04-22 16:30:00 +0200 (Tue, 12 Apr 2022) $
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_rcp_impres_4.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_rcp_impres_4.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/simple_types_4.0.xsd"/>
+	<xs:include schemaLocation="simple_types_4.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/4.0/fashion_shp_4.0.xsd
+++ b/XML-schema-definitions/4.0/fashion_shp_4.0.xsd
@@ -3,7 +3,7 @@
 $Date: 2022-04-22 16:30:00 +0200 (Tue, 12 Apr 2022) $$
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_shp_4.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_shp_4.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/simple_types_4.0.xsd"/>
+	<xs:include schemaLocation="simple_types_4.0.xsd"/>
 	<!-- 
 || Some general simple-type definitions
  -->

--- a/XML-schema-definitions/4.0/fashion_shp_confirm_4.0.xsd
+++ b/XML-schema-definitions/4.0/fashion_shp_confirm_4.0.xsd
@@ -3,8 +3,8 @@
 $Date: 2022-04-22 16:30:00 +0200 (Tue, 12 Apr 2022) $
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_shp_confirm_4.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_shp_confirm_4.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="C:\Users\bruno\mx-connect-api-public\XML-schema-definitions\4.0\simple_types_4.0.xsd"/>
-	<!-- <xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/simple_types_4.0.xsd"/> -->
+	<xs:include schemaLocation="simple_types_4.0.xsd"/>
+	<!-- <xs:include schemaLocation="simple_types_4.0.xsd"/> -->
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/4.0/fashion_shp_impres_4.0.xsd
+++ b/XML-schema-definitions/4.0/fashion_shp_impres_4.0.xsd
@@ -3,7 +3,7 @@
 $Date: 2022-04-22 16:30:00 +0200 (Tue, 12 Apr 2022) $
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_shp_impres_4.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_shp_impres_4.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/simple_types_4.0.xsd"/>
+	<xs:include schemaLocation="simple_types_4.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/4.0/fashion_sku_4.0.xsd
+++ b/XML-schema-definitions/4.0/fashion_sku_4.0.xsd
@@ -3,7 +3,7 @@
 $Date: 2022-04-22 13:00:00 +0200 (Tue, 12 Apr 2022) $
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_sku_4.0.xsd" xmlns:altova="http://www.altova.com/xml-schema-extensions" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_sku_4.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/simple_types_4.0.xsd"/>
+	<xs:include schemaLocation="simple_types_4.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/4.0/fashion_sku_impres_4.0.xsd
+++ b/XML-schema-definitions/4.0/fashion_sku_impres_4.0.xsd
@@ -3,7 +3,7 @@
 $Date: 2022-04-22 16:30:00 +0200 (Tue, 12 Apr 2022) $
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_sku_impres_4.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_sku_impres_4.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/simple_types_4.0.xsd"/>
+	<xs:include schemaLocation="simple_types_4.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/4.0/fashion_stock_level_4.0.xsd
+++ b/XML-schema-definitions/4.0/fashion_stock_level_4.0.xsd
@@ -3,7 +3,7 @@
 $Date: 2022-04-22 16:30:00 +0200 (Tue, 12 Apr 2022) $
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_stock_level_4.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_stock_level_4.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/simple_types_4.0.xsd"/>
+	<xs:include schemaLocation="simple_types_4.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->

--- a/XML-schema-definitions/4.0/fashion_stock_mutation_4.0.xsd
+++ b/XML-schema-definitions/4.0/fashion_stock_mutation_4.0.xsd
@@ -3,7 +3,7 @@
 $Date: 2022-04-22 16:30:00 +0200 (Tue, 12 Apr 2022) $
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_stock_mutation_4.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_stock_mutation_4.0.xsd" elementFormDefault="qualified">
-	<xs:include schemaLocation="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/simple_types_4.0.xsd"/>
+	<xs:include schemaLocation="simple_types_4.0.xsd"/>
 	<!-- 
 || Below the message-structure
  -->


### PR DESCRIPTION
also remove reference to github hosted simple_type file to prevent an unnecessary request to github for each xml that is validated