### PR TITLE
XSD update

### DIFF
--- a/XML-schema-definitions/3.0/fashion_shp_3.0.xsd
+++ b/XML-schema-definitions/3.0/fashion_shp_3.0.xsd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  $Revision: 48470 $
-$Date: 2021-04-16 14:52:40 +0200 (Fri, 16 Apr 2021) $
+<!--  $Revision: 220803-1 $
+$Date: 2022-08-03 12:00:00 +0200$
  -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_shp_3.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_shp_3.0.xsd" elementFormDefault="qualified">
+ <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_shp_3.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/3.0/fashion_shp_3.0.xsd" elementFormDefault="qualified">
 	<xs:include schemaLocation="simple_types_3.0.xsd"/>
 	<!-- 
 || Some general simple-type definitions
@@ -121,17 +121,17 @@ $Date: 2021-04-16 14:52:40 +0200 (Fri, 16 Apr 2021) $
 			<xs:element name="Type" type="tns:PartyType"/>
 			<xs:element name="Id" type="tns:ONum7" minOccurs="0"/>
 			<xs:element name="ExternalId" type="tns:OText35" minOccurs="0"/>
-			<xs:element name="Name1" type="tns:OText50" minOccurs="0"/>
+			<xs:element name="Name1" type="tns:Text50" minOccurs="1"/>
 			<xs:element name="Name2" type="tns:OText50" minOccurs="0"/>
-			<xs:element name="AddressLine1" type="tns:OText50" minOccurs="0"/>
+			<xs:element name="AddressLine1" type="tns:Text50" minOccurs="1"/>
 			<xs:element name="AddressLine2" type="tns:OText50" minOccurs="0"/>
 			<xs:element name="HouseNumber" type="tns:ONum6" minOccurs="0"/>
 			<xs:element name="HouseNumberExtension" type="tns:OText10" minOccurs="0"/>
 			<xs:element name="DeliveryInstruction" type="tns:OText30" minOccurs="0"/>
 			<xs:element name="PostalCode" type="tns:OText20" minOccurs="0"/>
-			<xs:element name="City" type="tns:OText50" minOccurs="0"/>
+			<xs:element name="City" type="tns:Text50" minOccurs="1"/>
 			<xs:element name="Region" type="tns:OText35" minOccurs="0"/>
-			<xs:element name="Country" type="tns:OText2" minOccurs="0"/>
+			<xs:element name="Country" type="tns:Text2" minOccurs="1"/>
 			<xs:element name="EmailAddress" type="tns:OText254" minOccurs="0"/>
 			<xs:element name="PhoneNumber" type="tns:OText40" minOccurs="0"/>
 			<xs:element name="MobileNumber" type="tns:OText40" minOccurs="0"/>

--- a/XML-schema-definitions/3.0/simple_types_3.0.xsd
+++ b/XML-schema-definitions/3.0/simple_types_3.0.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  $Revision: 220412 $ 
-$Date: 2022-04-22 12:00:00 +0200 (Tue, 12 Apr 2022) $
+<!--  $Revision: 220803-1 $
+$Date: 2022-08-03 12:00:00 +0200$
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
 	<!-- 
@@ -8,6 +8,12 @@ $Date: 2022-04-22 12:00:00 +0200 (Tue, 12 Apr 2022) $
  -->
 	<xs:simpleType name="Text">
 		<xs:restriction base="xs:normalizedString"/>
+	</xs:simpleType>
+	<xs:simpleType name="Text2">
+		<xs:restriction base="xs:normalizedString">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="2"/>
+		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="Text3">
 		<xs:restriction base="xs:normalizedString">

--- a/XML-schema-definitions/4.0/fashion_rcp_4.0.xsd
+++ b/XML-schema-definitions/4.0/fashion_rcp_4.0.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  $Revision: 220412 $ 
-$Date: 2022-04-22 11:00:00 +0200 (Tue, 12 Apr 2022) $
+<!--  $Revision: 220803-1 $
+$Date: 2022-08-03 12:00:00 +0200$
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_rcp_4.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_rcp_4.0.xsd" elementFormDefault="qualified">
 	<xs:include schemaLocation="simple_types_4.0.xsd"/>
@@ -353,6 +353,11 @@ Up to 2 certificates can apply to the same ShipmentLine, the following combinati
 			<xs:element name="Reference" type="tns:OText10" minOccurs="0">
 				<xs:annotation>
 					<xs:documentation>The reference the ordering party uses for the order line and that the ordering party can use to recognise the line.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="OriginalOutboundId" type="tns:OText40" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>In case of re-import a direct link to the original outbound order is required, due to CA regulations. The direct link enables the proof of (re-)export, which is required in order to avoid import duties for exports.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="StockType" type="tns:OText10" minOccurs="0">

--- a/XML-schema-definitions/4.0/fashion_shp_4.0.xsd
+++ b/XML-schema-definitions/4.0/fashion_shp_4.0.xsd
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  $Revision: 220412 $ 
-$Date: 2022-04-22 16:30:00 +0200 (Tue, 12 Apr 2022) $$
+<!--  $Revision: 220803-1 $
+$Date: 2022-08-03 12:00:00 +0200$
  -->
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_shp_4.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_shp_4.0.xsd" elementFormDefault="qualified">
+ <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_shp_4.0.xsd" targetNamespace="https://raw.githubusercontent.com/Modexpress/mx-connect-api-public/main/XML-schema-definitions/4.0/fashion_shp_4.0.xsd" elementFormDefault="qualified">
 	<xs:include schemaLocation="simple_types_4.0.xsd"/>
 	<!-- 
 || Some general simple-type definitions
@@ -329,10 +329,6 @@ For customs usage the amount is exclusive of VAT.</xs:documentation>
 			<xs:element name="Type" type="tns:PartyType">
 				<xs:annotation>
 					<xs:documentation>A type of party/address that applies to the order:
-- BuyerId; buyer, 
-      (known to Modexpress as a business relation based on 'Id' or 'ExternId' of the party)
-- ReceiverId; receiver/recipient/consignee, 
-      (known to Modexpress as a business relation based on 'Id' of the party)
 - ReceiverAddress; receiver/recipient/consignee address
 - SellerAddress; Seller/Shipper address
 - BuyerAddress; buyer address
@@ -357,7 +353,7 @@ For %Address types the ExterneId can be included as a reference in the order. Fo
 In case of a DropSiteAddress the ExternalId can be used for the pickuppoint-id/number.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Name1" type="tns:OText50" minOccurs="0">
+			<xs:element name="Name1" type="tns:Text50" minOccurs="1">
 				<xs:annotation>
 					<xs:documentation>The name of the party.
 Order of display on documents: line 1
@@ -374,7 +370,7 @@ Order of display on documents: line 2
 Only applicable for the %Address party types.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="AddressLine1" type="tns:OText50" minOccurs="0">
+			<xs:element name="AddressLine1" type="tns:Text50" minOccurs="1">
 				<xs:annotation>
 					<xs:documentation>The street that applies to the party.
 Order of display on documents: line 4
@@ -426,7 +422,7 @@ Mandatory for parties with Country = NL.
 </xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="City" type="tns:OText50" minOccurs="0">
+			<xs:element name="City" type="tns:Text50" minOccurs="1">
 				<xs:annotation>
 					<xs:documentation>The town/city that applies to the party.
 Order of display on documents: line 6
@@ -442,7 +438,7 @@ Order of display on documents: line 7
 Only applicable for the %Address party types.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Country" type="tns:OText2" minOccurs="0">
+			<xs:element name="Country" type="tns:Text2" minOccurs="1">
 				<xs:annotation>
 					<xs:documentation>The country that applies to the party. The designation should be made according to iso2 code.
 Order of display on documents: line 8 (country name will be displayed)

--- a/XML-schema-definitions/4.0/simple_types_4.0.xsd
+++ b/XML-schema-definitions/4.0/simple_types_4.0.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  $Revision: 220412 $ 
-$Date: 2022-04-22 16:30:00 +0200 (Tue, 12 Apr 2022) $
+<!--  $Revision: 220803-1 $
+$Date: 2022-08-03 12:00:00 +0200$
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
 	<!-- 
@@ -8,6 +8,12 @@ $Date: 2022-04-22 16:30:00 +0200 (Tue, 12 Apr 2022) $
  -->
 	<xs:simpleType name="Text">
 		<xs:restriction base="xs:normalizedString"/>
+	</xs:simpleType>
+	<xs:simpleType name="Text2">
+		<xs:restriction base="xs:normalizedString">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="2"/>
+		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="Text3">
 		<xs:restriction base="xs:normalizedString">


### PR DESCRIPTION
- SHP party fields: Name1, AddressLine1, City and Country (3.0 and 4.0) are now mandatory.
- RCP added PurchaseOrderLine.OriginalOutboundId (4.0)
