### PR TITLE
XSD v4.0 update

### DIFF
--- a/XML-schema-definitions/4.0/fashion_sku_4.0.xsd
+++ b/XML-schema-definitions/4.0/fashion_sku_4.0.xsd
@@ -140,32 +140,32 @@ If the identification contains letters, they must be in uppercase.</xs:documenta
 These values are not visible on our frontend systems (such as customer portal) and are not available in WMS.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="ExternalDivisionCode" type="tns:Text50" minOccurs="0" maxOccurs="1">
+			<xs:element name="ExternalDivisionCode" type="tns:OText50" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>An external division code identifier. When populated this value is returned on interface messages from Modexpress at Article level.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="ExternalArticleId" type="tns:Text70" minOccurs="0" maxOccurs="1">
+			<xs:element name="ExternalArticleId" type="tns:OText70" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>An external article code identifier. When populated this value is returned on interface messages from Modexpress at Article level.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="ExternalSizeCode" type="tns:Text50" minOccurs="0" maxOccurs="1">
+			<xs:element name="ExternalSizeCode" type="tns:OText50" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>An external size code identifier. When populated this value is returned on interface messages from Modexpress at Article level.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="ExternalColourCode" type="tns:Text50" minOccurs="0" maxOccurs="1">
+			<xs:element name="ExternalColourCode" type="tns:OText50" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>An external colour code identifier. When populated this value is returned on interface messages from Modexpress at Article level.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="ExternalUnitOfMeasure" type="tns:Text10" minOccurs="0" maxOccurs="1">
+			<xs:element name="ExternalUnitOfMeasure" type="tns:OText10" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>An external unit of measure for the particular SKU. When populated this value is returned on interface messages from Modexpress at Article level.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="ExternalProfitCenter" type="tns:Text50" minOccurs="0" maxOccurs="1">
+			<xs:element name="ExternalProfitCenter" type="tns:OText50" minOccurs="0" maxOccurs="1">
 				<xs:annotation>
 					<xs:documentation>Defines a profit center that the SKU belongs to. When populated this value is returned on interface messages from Modexpress at Article level.</xs:documentation>
 				</xs:annotation>

--- a/XML-schema-definitions/4.0/simple_types_4.0.xsd
+++ b/XML-schema-definitions/4.0/simple_types_4.0.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--  $Revision: 230623-1 $
-$Date: 2023-06-23 12:00:00 +0200$
+<!--  $Revision: 230915-2 $
+$Date: 2023-09-15 15:45:00 +0200$
  -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
 	<!-- 
@@ -410,6 +410,14 @@ $Date: 2023-06-23 12:00:00 +0200$
 			<xs:element name="Id" type="TypSkuId"/>
 			<xs:element name="LotNumber" type="OText20" minOccurs="0"/>
 			<xs:element name="Code" type="OText35" minOccurs="0"/>
+			<xs:element name="ExternalDivisionCode" type="OText50" minOccurs="0"/>
+			<xs:element name="ExternalArticleId" type="OText70" minOccurs="0"/>
+			<xs:element name="ExternalSizeCode" type="OText50" minOccurs="0"/>
+			<xs:element name="ExternalColourCode" type="OText50" minOccurs="0"/>
+			<xs:element name="ExternalUnitOfMeasure" type="OText10" minOccurs="0"/>
+			<xs:element name="ExternalProfitCenter" type="OText50" minOccurs="0"/>
+			<xs:element name="PiecesPerPrepack" type="ONum9" minOccurs="0"/>
+			<xs:element name="PrepacksPerMasterCarton" type="ONum9" minOccurs="0"/>
 		</xs:sequence>
 	</xs:complexType>
 	<xs:complexType name="ArticleOrCode">


### PR DESCRIPTION
Added the following fields to the SKU interface (xsd 4.0)
 - ExternalDivisionCode
 - ExternalArticleId
 - ExternalSizeCode
 - ExternalColourCode
 - ExternalUnitOfMeasure
 - ExternalProfitCenter
 - PiecesPerPrepack
 - PrepacksPerMasterCarton
 
Previously added fields will now return on the following interface message if sent with the SKU data.
- RCP-EXEC
- SHP-EXEC
- STM
- STL
